### PR TITLE
feat: Add automatic GTFS data refresh when no service is found

### DIFF
--- a/data_parser.py
+++ b/data_parser.py
@@ -15,25 +15,34 @@ class ParseRTLData:
         self.schedule_zipfile = RTL_GTFS_ZIP_FILE
         _LOGGER.info(f"ParseRTLData init")
         
-        data_dir = os.environ.get("GTFS_DATA_DIR", os.path.dirname(os.path.abspath(__file__)))
-        file = os.path.join(data_dir, self.schedule_zipfile)
+        self.data_dir = os.environ.get("GTFS_DATA_DIR", os.path.dirname(os.path.abspath(__file__)))
+        self.file_path = os.path.join(self.data_dir, self.schedule_zipfile)
+        self._load_data()
 
+    def _load_data(self, force_download=False):
+        """Download and load GTFS data into memory."""
         try:
-            if not (os.path.isfile(file)) or is_file_expired(file):
-                self._download_gtfs_file(file)
+            if force_download or not (os.path.isfile(self.file_path)) or is_file_expired(self.file_path):
+                self._download_gtfs_file(self.file_path)
                 _LOGGER.info(f"Downloaded a new zip file from [{RTL_GTFS_URL}]")
 
-            with zipfile.ZipFile(file) as my_zip:
+            with zipfile.ZipFile(self.file_path) as my_zip:
                 self.stops = read_csv(my_zip.open('stops.txt'), index_col='stop_code')
                 self.calendar = read_csv(my_zip.open('calendar.txt'))
                 self.stop_times = read_csv(my_zip.open('stop_times.txt'), index_col='stop_id')
                 self.trips = read_csv(my_zip.open('trips.txt'))
         except FileNotFoundError:
-            _LOGGER.error(f"GTFS file not found at {file}. Please check the file path and permissions.")
+            _LOGGER.error(f"GTFS file not found at {self.file_path}. Please check the file path and permissions.")
             raise
         except (zipfile.BadZipFile, pandas.errors.ParserError) as e:
             _LOGGER.error(f"An error occurred while parsing the GTFS file: {e}")
             raise
+
+    def refresh(self, force=False):
+        """Check if data needs to be refreshed and reload if necessary."""
+        if force or is_file_expired(self.file_path):
+            _LOGGER.info(f"Refreshing GTFS data (force={force})...")
+            self._load_data(force_download=force)
 
     @staticmethod
     def _download_gtfs_file(zipfile_location) -> None:
@@ -44,6 +53,7 @@ class ParseRTLData:
 
     def get_stop_id(self, stop_code: int) -> int:
         """ Retrieve the stop_id based on a stop_code """
+        self.refresh()
         if stop_code not in self.stops.index:
             _LOGGER.error(f"Stop code {stop_code} not found in the GTFS data.")
             return None
@@ -100,13 +110,20 @@ class ParseRTLData:
 
     def get_next_stop(self, stop_id: int, parm_datetime: datetime.datetime) -> Optional[Series]:
         """Retrieve the next stop information"""
+        self.refresh()
         _LOGGER.info(f"Retrieving next stop for stop_id {stop_id} at {parm_datetime}")
 
         try:
             today_service_id = self._get_service_id(parm_datetime.date())
-        except ValueError as e:
-            _LOGGER.error(e)
-            return None
+        except ValueError:
+            # If no service found, try refreshing data once just in case the file was updated but not yet expired
+            _LOGGER.info(f"No service found for {parm_datetime.date()}, attempting a forced refresh.")
+            self.refresh(force=True)
+            try:
+                today_service_id = self._get_service_id(parm_datetime.date())
+            except ValueError as e:
+                _LOGGER.error(e)
+                return None
 
         today_schedule = self._get_today_schedule(today_service_id, stop_id)
         

--- a/reproduce_issue.py
+++ b/reproduce_issue.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import datetime
+from zipfile import ZipFile
+from io import BytesIO
+
+from data_parser import ParseRTLData
+from const import RTL_GTFS_ZIP_FILE
+
+class TestIssueReproduction(unittest.TestCase):
+    def setUp(self):
+        self.zip_file = RTL_GTFS_ZIP_FILE
+        # Ensure no zip file exists initially
+        if os.path.exists(self.zip_file):
+            os.remove(self.zip_file)
+
+    def tearDown(self):
+        if os.path.exists(self.zip_file):
+            os.remove(self.zip_file)
+
+    def create_gtfs_zip(self, calendar_data):
+        zip_buffer = BytesIO()
+        with ZipFile(zip_buffer, 'w') as zf:
+            zf.writestr('stops.txt', 'stop_id,stop_code,stop_name\n1,123,Test Stop 1')
+            zf.writestr('calendar.txt', calendar_data)
+            zf.writestr('stop_times.txt', 'trip_id,arrival_time,departure_time,stop_id,stop_sequence\n1,10:00:00,10:00:30,1,1')
+            zf.writestr('trips.txt', 'route_id,service_id,trip_id,trip_headsign\n101,1,1,To Downtown')
+        return zip_buffer.getvalue()
+
+    @patch('data_parser.requests.get')
+    @patch('data_parser.is_file_expired', return_value=False)
+    def test_refresh_on_no_service_found(self, mock_is_file_expired, mock_requests_get):
+        # 1. Initial data without March 15th 2026
+        # March 15 2026 is a Sunday
+        calendar_v1 = 'service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\n1,1,1,1,1,1,0,0,20260101,20260310'
+        
+        # 2. Updated data with March 15th 2026
+        calendar_v2 = 'service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date\n1,1,1,1,1,1,1,1,20260101,20261231'
+        
+        zip_v1 = self.create_gtfs_zip(calendar_v1)
+        zip_v2 = self.create_gtfs_zip(calendar_v2)
+
+        # First download returns v1
+        mock_response_v1 = MagicMock()
+        mock_response_v1.content = zip_v1
+        
+        # Second download (on refresh) returns v2
+        mock_response_v2 = MagicMock()
+        mock_response_v2.content = zip_v2
+        
+        mock_requests_get.side_effect = [mock_response_v1, mock_response_v2]
+
+        # Initialize parser (should call download for v1)
+        parser = ParseRTLData()
+        self.assertEqual(mock_requests_get.call_count, 1)
+
+        # Attempt to get next stop for March 15th 2026
+        test_datetime = datetime.datetime(2026, 3, 15, 9, 0, 0)
+        
+        # This should trigger a refresh because March 15th is not in v1
+        # Mock is_file_expired to False to ensure it's the "force=True" that triggers it
+        next_stop = parser.get_next_stop(1, test_datetime)
+        
+        self.assertIsNotNone(next_stop)
+        self.assertEqual(mock_requests_get.call_count, 2)
+        self.assertEqual(next_stop.arrival_time, '10:00:00')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Implemented refresh() method in ParseRTLData to reload GTFS data.
- Automatically trigger a forced refresh if a requested date is not found in the current calendar.
- Added check for file expiration (24h) before data access.
- Added reproduction test script reproduce_issue.py.